### PR TITLE
Enable adding css class 'weekend'

### DIFF
--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -168,6 +168,10 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     color: #999;
 }
 
+.weekend .pika-button {
+    color: #c05456;
+}
+
 .is-today .pika-button {
     color: #33aaff;
     font-weight: bold;

--- a/pikaday.js
+++ b/pikaday.js
@@ -213,6 +213,8 @@
         // show week numbers at head of row
         showWeekNumber: false,
 
+        setWeekendClass: false,
+
         // used internally (don't config outside)
         minYear: 0,
         maxYear: 9999,
@@ -295,6 +297,9 @@
         }
         if (opts.isEndRange) {
             arr.push('is-endrange');
+        }
+        if (opts.setWeekendClass) {
+          arr.push('weekend');
         }
         return '<td data-day="' + opts.day + '" class="' + arr.join(' ') + '">' +
                  '<button class="pika-button pika-day" type="button" ' +
@@ -985,6 +990,7 @@
                                  (opts.maxDate && day > opts.maxDate) ||
                                  (opts.disableWeekends && isWeekend(day)) ||
                                  (opts.disableDayFn && opts.disableDayFn(day)),
+                    setWeekendClass = (opts.setWeekendClass && isWeekend(day)),
                     dayConfig = {
                         day: 1 + (i - before),
                         month: month,
@@ -995,7 +1001,8 @@
                         isEmpty: isEmpty,
                         isStartRange: isStartRange,
                         isEndRange: isEndRange,
-                        isInRange: isInRange
+                        isInRange: isInRange,
+                        setWeekendClass: setWeekendClass
                     };
 
                 row.push(renderDay(dayConfig));


### PR DESCRIPTION
This PR can generate 'weekend' css class when you add flag 'setWeekendClass' to initializer.
For example, in Japan, weekend day's color can be changed.

<img width="260" alt="enable_adding_weekend_class" src="https://cloud.githubusercontent.com/assets/689830/9376223/0d88c450-4745-11e5-9f2a-aab36610b1cb.png">
